### PR TITLE
workaround for compile error using enumerate_ref

### DIFF
--- a/crates/vk-gen-examples/src/examples/circuit_layout.rs
+++ b/crates/vk-gen-examples/src/examples/circuit_layout.rs
@@ -10,6 +10,7 @@ use std::marker::PhantomData;
 
 /// This represents an advice column at a certain row in the ConstraintSystem
 #[derive(Copy, Clone, Debug)]
+#[allow(dead_code)]
 pub struct Variable(Column<Advice>, usize);
 
 #[derive(Clone)]


### PR DESCRIPTION
There is a compile error for the latest branch which related to enumerate_ref, and it's replaced by a workaround.
```
error: cannot pass `|(&_, &crypto_algebra::Element<bn254_algebra::Fr>)|` to a function which expects argument of type `|(u64, &crypto_algebra::Element<bn254_algebra::Fr>)|`
┌─ /Users/benliu/work/zkmove/halo2-verifier.move/packages/verifier/sources/shplonk.move:237:44
│
237 │               vector::enumerate_ref(&points, |k, x_k| {
│ ╭────────────────────────────────────────────^
238 │ │                 if (k != j) {
239 │ │                     vector::push_back(&mut denom, bn254_utils::invert(&crypto_algebra::sub(x_j, x_k)));
240 │ │                 };
241 │ │             });
│ ╰─────────────^

error: cannot pass `|(&_, &crypto_algebra::Element<bn254_algebra::Fr>)|` to a function which expects argument of type `|(u64, &crypto_algebra::Element<bn254_algebra::Fr>)|`
┌─ /Users/benliu/work/zkmove/halo2-verifier.move/packages/verifier/sources/shplonk.move:234:40
│
234 │           vector::enumerate_ref(&points, |j, x_j| {
│ ╭────────────────────────────────────────^
235 │ │             let denom = vector::empty();
236 │ │
237 │ │             vector::enumerate_ref(&points, |k, x_k| {
· │
243 │ │             vector::push_back(&mut denoms, denom);
244 │ │         });
│ ╰─────────^
```